### PR TITLE
Fix mint cap check and add coverage

### DIFF
--- a/src/samples/MinterSample.sol
+++ b/src/samples/MinterSample.sol
@@ -19,13 +19,13 @@ contract MinterSample is OwnableUpgradeable {
     /// @dev Maximum allowable amount of tokens that can be minted through this contract
     uint256 public mintCap;
 
-    /// @dev Maximum allowable amount of tokens that can be minted through this contract
+    /// @dev Tracks the total amount of tokens minted through this contract
     uint256 public mintedAmount;
 
-    /// @dev Mint rate in basis points (1 = 0.01%, 100 = 1%, 10000 = 100%)
+    /// @dev Mint rate expressed as a percentage where 100 means 100%
     uint16 public mintRate;
 
-    /// @dev Default mint rate in basis points (1 = 0.01%, 100 = 1%, 10000 = 100%)
+    /// @dev Default mint rate expressed as a percentage where 100 means 100%
     uint16 public constant DEFAULT_MINTRATE = 100;
 
     /// @dev A flag to disable whitelist checks
@@ -68,7 +68,10 @@ contract MinterSample is OwnableUpgradeable {
      */
     modifier withinMintCap() {
         uint256 mintAmount = _mintAmount(msg.value);
-        require(mintAmount <= mintCap, "Mint cap exceeded");
+        require(
+            mintedAmount + mintAmount <= mintCap,
+            "Mint cap exceeded"
+        );
         _;
         mintedAmount += mintAmount;
     }
@@ -201,7 +204,7 @@ contract MinterSample is OwnableUpgradeable {
 
     /**
      * @dev Updates the mint rate
-     * @param mintRate_ The new mint rate value in basis points (1 = 0.01%, 100 = 1%, 10000 = 100%)
+     * @param mintRate_ The new mint rate value expressed as a percentage where 100 = 100%
      */
     function updateMintRate(uint16 mintRate_) public onlyOwner {
         require(mintRate_ > 0, "Rate must be greater than 0");

--- a/test/MinterSample.t.sol
+++ b/test/MinterSample.t.sol
@@ -214,6 +214,27 @@ contract MinterSampleTest is Test {
         minter.mint{value: minCap + 1}(minCap + 1);
     }
 
+    function test_mintCap() public {
+        MinterSample minter = MinterSample(payable(address(minterProxy)));
+        vm.prank(poasAdmin);
+        poas.grantRole(OPERATOR_ROLE, address(minterProxy));
+        vm.prank(owner);
+        minter.addWhitelist(whitelist);
+
+        uint256 halfCap = minCap / 2;
+
+        vm.prank(buyer1);
+        minter.mint{value: halfCap}(halfCap);
+        vm.prank(buyer1);
+        minter.mint{value: halfCap}(halfCap);
+
+        assertEq(minter.mintedAmount(), minCap);
+
+        vm.expectRevert("Mint cap exceeded");
+        vm.prank(buyer1);
+        minter.mint{value: amount}(amount);
+    }
+
     function test_mint_disableWhitelistCheck() public {
         MinterSample minter = MinterSample(payable(address(minterProxy)));
         vm.prank(poasAdmin);


### PR DESCRIPTION
## Summary
- ensure minting cannot exceed overall cap
- document mintRate and mintedAmount usage
- test accumulated mints reaching the cap

## Testing
- `forge test -q` *(fails: error sending request for url)*

------
https://chatgpt.com/codex/tasks/task_e_683fd68754f08330863a09ecf6906961