### PR TITLE
Use allowance map for whitelisted minting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p-oas-contract",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p-oas-contract",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "prettier": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "p-oas-contract",
   "description": "Collateral-backed point OAS token contract on the OAS chain.",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "license": "MIT",
   "scripts": {
     "compile": "forge build",


### PR DESCRIPTION
## Summary
- store whitelist mint caps as allowances in `whitelistWithAllowanceMap`
- increment allowance on whitelist addition and subtract on mint
- update tests for new whitelist allowance logic
- bump package version to 1.0.5

## Testing
- `npm run test` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684aceb0858883308882a3633c3336ec